### PR TITLE
Remember previous item key to invoke a trigger as the last status changed item

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -19,12 +19,13 @@ import (
 )
 
 var (
-	Namespace   = "dashboard"
-	ConsulAddr  = "127.0.0.1:8500"
-	Version     string
-	ExtAssetDir string
-	Nodes       []Node
-	mutex       sync.RWMutex
+	Namespace           = "dashboard"
+	ConsulAddr          = "127.0.0.1:8500"
+	PreviousCategoryKey = map[string]string{}
+	Version             string
+	ExtAssetDir         string
+	Nodes               []Node
+	mutex               sync.RWMutex
 )
 
 type KVPair struct {
@@ -241,6 +242,8 @@ func watchForTrigger(command string) {
 				currentItem[item.Category] = item
 			} else if currentItem[item.Category].Status < item.Status {
 				currentItem[item.Category] = item
+			} else if PreviousCategoryKey[item.Category] == item.Key {
+				currentItem[item.Category] = item
 			}
 		}
 		for category, item := range currentItem {
@@ -252,6 +255,7 @@ func watchForTrigger(command string) {
 				// status changed. invoking trigger.
 				log.Printf("[info] %s: status %s -> %s", category, lastStatus[category], item.Status)
 				lastStatus[category] = item.Status
+				PreviousCategoryKey[category] = item.Key
 				b, _ := json.Marshal(item)
 				err := invokePipe(command, bytes.NewReader(b))
 				if err != nil {


### PR DESCRIPTION
Hi,

This pr is to change `lastStatus` map to store one previous item when to use trigger option.

I expected that when an item's status (Info, Warning, or Danger) changes the item's data would be input in stdin, but if category has multiple keys, a first item which is the same status as the actually changed item is picked up.

POST with curl:

``` bash
## store keys into category
$ curl -X PUT -d "Success" http://localhost:8500/v1/kv/dashboard/debug/tkyshm/key1\?flags=1422597159000
$ curl -X PUT -d "Success" http://localhost:8500/v1/kv/dashboard/debug/tkyshm/key2\?flags=1422597159000
$ curl -X PUT -d "Success" http://localhost:8500/v1/kv/dashboard/debug/tkyshm/key3\?flags=1422597159000

## change key3 status success -> danger, dagner -> success
$ curl -X PUT -d "Danger" http://localhost:8500/v1/kv/dashboard/debug/tkyshm/key3\?flags=1422597159002
$ curl -X PUT -d "key3 is successful" http://localhost:8500/v1/kv/dashboard/debug/tkyshm/key3\?flags=1422597159000
```

trigger stdin:

```
danger:  {"category":"debug","node":"tkyshm","address":"127.0.0.1","timestamp":"2015-01-30 14:52:39 +0900","status":"danger","key":"key3","data":"Danger"}
success:  {"category":"debug","node":"tkyshm","address":"127.0.0.1","timestamp":"2015-01-30 14:52:39 +0900","status":"success","key":"key1","data":"Success"}
```

I would expect that danger -> success stdin is:

```
success:  {"category":"debug","node":"tkyshm","address":"127.0.0.1","timestamp":"2015-01-30 14:52:39 +0900","status":"success","key":"key3","data":"key3 is successful"}
```

So, I changed to remember one previous item as to all items.

Thanks.
